### PR TITLE
docs: add MIT license and expand README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2025 gitusp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,84 @@
 pr-review.nvim
 ===
 
-TODO: write something
+A Neovim plugin for GitHub PR review workflows focused on reading and navigating pull request information directly from your editor.
+
+## Features
+
+- Browse and select PRs from a searchable list
+- Checkout PRs directly from Neovim
+- Review PRs with side-by-side diffs using fugitive
+- Display PR comments as diagnostics
+- Toggle visibility of PR comment threads
+
+## Philosophy
+
+This plugin focuses on **reading and reviewing** PRs rather than writing comments:
+
+- Simplifies the PR review workflow
+- Avoids reimplementing the full GitHub web UI
+- Stays focused on the strengths of terminal-based workflows
+- Minimizes the learning curve with familiar interfaces
+
+## Requirements
+
+- [Git](https://git-scm.com/)
+- [GitHub CLI (gh)](https://cli.github.com/)
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua)
+- [vim-fugitive](https://github.com/tpope/vim-fugitive)
+
+## Installation
+
+Using [lazy.nvim](https://github.com/folke/lazy.nvim):
+
+```lua
+{
+  "gitusp/pr-review.nvim",
+  dependencies = {
+    "ibhagwan/fzf-lua",
+    "tpope/vim-fugitive",
+  },
+  lazy = true,
+  cmd = { "PRBrowse", "PRReview", "PRFetchThreads", "PRShowThreads", "PRHideThreads", "PRToggleThreads" },
+}
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `:PRBrowse` | Open a searchable list of PRs |
+| `:PRReview` | Review the current PR with side-by-side diffs |
+| `:PRFetchThreads` | Fetch comment threads for the current PR |
+| `:PRShowThreads` | Display PR comment threads as diagnostics |
+| `:PRHideThreads` | Hide PR comment threads |
+| `:PRToggleThreads` | Toggle visibility of PR comment threads |
+
+## Usage
+
+### Browsing PRs
+
+1. Run `:PRBrowse` to see a list of PRs
+2. Actions in the PR browser:
+   - `Enter`: Open PR in your web browser
+   - `Ctrl-o`: Checkout the selected PR
+   - `Ctrl-r`: Checkout and start reviewing the PR
+
+### Reviewing PRs
+
+When on a PR branch:
+
+1. Run `:PRReview` to:
+   - Fetch PR comment threads
+   - Open side-by-side diffs using fugitive
+
+### Working with Comment Threads
+
+- `:PRFetchThreads` - Load PR comments as diagnostics
+- `:PRShowThreads` - Show comment threads (after fetching)
+- `:PRHideThreads` - Hide comment threads
+- `:PRToggleThreads` - Toggle visibility of comment threads
+
+## Health Check
+
+Run `:checkhealth pr-review` to verify that all dependencies are properly installed.

--- a/doc/pr-review.txt
+++ b/doc/pr-review.txt
@@ -1,0 +1,118 @@
+*pr-review.txt*   Plugin for GitHub PR review workflows in Neovim
+
+==============================================================================
+CONTENTS                                                   *pr-review-contents*
+
+  1. Introduction............................................|pr-review-intro|
+  2. Requirements..........................................|pr-review-requirements|
+  3. Installation.........................................|pr-review-installation|
+  4. Commands..............................................|pr-review-commands|
+  5. Usage.................................................|pr-review-usage|
+    5.1. Browsing PRs......................................|pr-review-browsing|
+    5.2. Reviewing PRs.....................................|pr-review-reviewing|
+    5.3. Working with Comment Threads......................|pr-review-comments|
+  6. Health Check..........................................|pr-review-health|
+
+==============================================================================
+1. INTRODUCTION                                               *pr-review-intro*
+
+A Neovim plugin for GitHub PR review workflows focused on reading and
+navigating pull request information directly from your editor.
+
+Philosophy~
+
+This plugin focuses on *reading and reviewing* PRs rather than writing comments:
+
+- Simplifies the PR review workflow
+- Avoids reimplementing the full GitHub web UI
+- Stays focused on the strengths of terminal-based workflows
+- Minimizes the learning curve with familiar interfaces
+
+Features~
+
+- Browse and select PRs from a searchable list
+- Checkout PRs directly from Neovim
+- Review PRs with side-by-side diffs using fugitive
+- Display PR comments as diagnostics 
+- Toggle visibility of PR comment threads
+
+==============================================================================
+2. REQUIREMENTS                                        *pr-review-requirements*
+
+- Git (https://git-scm.com/)
+- GitHub CLI (gh) (https://cli.github.com/)
+- fzf-lua (https://github.com/ibhagwan/fzf-lua)
+- vim-fugitive (https://github.com/tpope/vim-fugitive)
+
+==============================================================================
+3. INSTALLATION                                        *pr-review-installation*
+
+Using lazy.nvim (https://github.com/folke/lazy.nvim):
+>lua
+  {
+    "gitusp/pr-review.nvim",
+    dependencies = {
+      "ibhagwan/fzf-lua",
+      "tpope/vim-fugitive",
+    },
+    lazy = true,
+    cmd = { "PRBrowse", "PRReview", "PRFetchThreads", "PRShowThreads", 
+             "PRHideThreads", "PRToggleThreads" },
+  }
+<
+
+==============================================================================
+4. COMMANDS                                              *pr-review-commands*
+
+                                                                  *:PRBrowse*
+:PRBrowse               Open a searchable list of PRs
+
+                                                                  *:PRReview*
+:PRReview               Review the current PR with side-by-side diffs
+
+                                                            *:PRFetchThreads*
+:PRFetchThreads         Fetch comment threads for the current PR
+
+                                                             *:PRShowThreads*
+:PRShowThreads          Display PR comment threads as diagnostics 
+
+                                                             *:PRHideThreads*
+:PRHideThreads          Hide PR comment threads
+
+                                                           *:PRToggleThreads*
+:PRToggleThreads        Toggle visibility of PR comment threads
+
+==============================================================================
+5. USAGE                                                     *pr-review-usage*
+
+5.1 Browsing PRs                                         *pr-review-browsing*
+
+1. Run |:PRBrowse| to see a list of PRs
+2. Actions in the PR browser:
+   - Enter: Open PR in your web browser
+   - Ctrl-o: Checkout the selected PR
+   - Ctrl-r: Checkout and start reviewing the PR
+
+5.2 Reviewing PRs                                       *pr-review-reviewing*
+
+When on a PR branch:
+
+1. Run |:PRReview| to:
+   - Fetch PR comment threads
+   - Open side-by-side diffs using fugitive
+
+5.3 Working with Comment Threads                         *pr-review-comments*
+
+- |:PRFetchThreads| - Load PR comments as diagnostics
+- |:PRShowThreads| - Show comment threads (after fetching)
+- |:PRHideThreads| - Hide comment threads
+- |:PRToggleThreads| - Toggle visibility of comment threads
+
+==============================================================================
+6. HEALTH CHECK                                             *pr-review-health*
+
+Run `:checkhealth pr-review` to verify that all dependencies are properly 
+installed.
+
+==============================================================================
+vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Add detailed README documentation outlining plugin features, dependencies, installation instructions, available commands, and usage examples. Include an MIT license file to clarify the project's open source status.